### PR TITLE
chore: replace geo_types with geo for more functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ keywords = ["geo", "polygon", "svg", "visualization"]
 categories = ["development-tools::debugging", "graphics", "multimedia::images", "visualization"]
 
 [dependencies]
-geo-types = "0.7.11"
+geo = { version = "0.27.0", default-features = false }
 num-traits = "0.2.17"

--- a/src/svg_impl.rs
+++ b/src/svg_impl.rs
@@ -1,5 +1,5 @@
 use crate::{Style, ToSvgStr, ViewBox};
-use geo_types::{
+use geo::{
     Coord, CoordNum, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
     MultiPolygon, Point, Polygon, Rect, Triangle,
 };
@@ -254,7 +254,7 @@ impl<T: ToSvgStr> ToSvgStr for Vec<T> {
 #[cfg(test)]
 mod tests {
     use crate::{Color, ToSvg};
-    use geo_types::{LineString, Point, Polygon};
+    use geo::{LineString, Point, Polygon};
 
     #[test]
     fn test_point() {

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use geo_types::{Coord, CoordNum};
+use geo::{Coord, CoordNum};
 
 use crate::{Style, ToSvgStr, ViewBox};
 


### PR DESCRIPTION
Instead of just using `geo_types` we'll pull in all of `geo` with this PR. This is to make algorithms accessible which are useful for more detailed visualizations.