### PR TITLE
fix: use only one stroke for LineStrings

### DIFF
--- a/src/svg_impl.rs
+++ b/src/svg_impl.rs
@@ -82,21 +82,13 @@ impl<T: CoordNum> ToSvgStr for LineString<T> {
         } else {
             self.0.iter()
         };
-        // .next() is guarunteed to be Some(...) because the length was checked above.
+        // .next() is guaranteed to be Some(...) because the length was checked above.
         let first_point = point_iter.next().unwrap();
-        let mut path_string = format!(
-            "M {x:?} {y:?}",
-            x = first_point.x,
-            y = first_point.y,
-        );
+        let mut path_string = format!("M {x:?} {y:?}", x = first_point.x, y = first_point.y,);
         for point in point_iter {
-            path_string += &format!(
-                " L {x:?} {y:?}",
-                x = point.x,
-                y = point.y,
-            );
+            path_string += &format!(" L {x:?} {y:?}", x = point.x, y = point.y,);
         }
-        if self.is_closed() { 
+        if self.is_closed() {
             path_string += " Z";
         }
         format!(
@@ -339,18 +331,17 @@ mod tests {
 
     #[test]
     fn test_closed_line_string() {
-        let closed_line_string_result = 
-            LineString(vec![
-                (210.0, 0.0).into(),
-                (300.0, 0.0).into(),
-                (300.0, 90.0).into(),
-                (210.0, 90.0).into(),
-                (210.0, 0.0).into(),
-            ])
-            .to_svg()
-            .with_fill_color(Color::Named("black"))
-            .with_stroke_color(Color::Named("red"))
-            .to_string();
+        let closed_line_string_result = LineString(vec![
+            (210.0, 0.0).into(),
+            (300.0, 0.0).into(),
+            (300.0, 90.0).into(),
+            (210.0, 90.0).into(),
+            (210.0, 0.0).into(),
+        ])
+        .to_svg()
+        .with_fill_color(Color::Named("black"))
+        .with_stroke_color(Color::Named("red"))
+        .to_string();
         assert_eq!(
             closed_line_string_result,
             r#"<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" viewBox="209 -1 92 92"><path d="M 210.0 0.0 L 300.0 0.0 L 300.0 90.0 L 210.0 90.0 Z" fill="black" stroke="red"/></svg>"#
@@ -359,21 +350,19 @@ mod tests {
 
     #[test]
     fn test_open_line_string() {
-        let closed_line_string_result = 
-            LineString(vec![
-                (210.0, 0.0).into(),
-                (300.0, 0.0).into(),
-                (300.0, 90.0).into(),
-                (210.0, 90.0).into(),
-            ])
-            .to_svg()
-            .with_fill_color(Color::Named("black"))
-            .with_stroke_color(Color::Named("red"))
-            .to_string();
+        let closed_line_string_result = LineString(vec![
+            (210.0, 0.0).into(),
+            (300.0, 0.0).into(),
+            (300.0, 90.0).into(),
+            (210.0, 90.0).into(),
+        ])
+        .to_svg()
+        .with_fill_color(Color::Named("black"))
+        .with_stroke_color(Color::Named("red"))
+        .to_string();
         assert_eq!(
             closed_line_string_result,
             r#"<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" viewBox="209 -1 92 92"><path d="M 210.0 0.0 L 300.0 0.0 L 300.0 90.0 L 210.0 90.0" fill="black" stroke="red"/></svg>"#
         )
     }
-
 }

--- a/src/svg_impl.rs
+++ b/src/svg_impl.rs
@@ -91,15 +91,7 @@ impl<T: CoordNum> ToSvgStr for LineString<T> {
         if self.is_closed() {
             path_string += " Z";
         }
-        format!(
-            r#"<path d="{path_string}"{style}/>"#,
-            path_string = path_string,
-            style = Style {
-                fill: None,
-                fill_opacity: Some(0.0),
-                ..style.clone()
-            }
-        )
+        format!(r#"<path d="{path_string}"{style}/>"#,)
     }
 
     fn viewbox(&self, style: &Style) -> ViewBox {


### PR DESCRIPTION
Instead of converting a LineString (or MultiLineString) into a bunch of small line paths, convert it into a single continuous path. This should lead to better results when using `with_stroke_width`, as the renderer will be able to appropriate apply its join/cap styles, instead of having to treat each corner as the end/start of a segment, leading to weird artifacts near the corners. For closed loops, it's important to close with the "Z" command to make sure that renderers treat the starting point as being a corner, rather than the start and end of a path separately. The [geo_types library's docs suggest this is the correct semantics for LineString](https://docs.rs/geo/latest/geo/geometry/struct.LineString.html#method.is_closed).

To avoid drawing closed LineStrings as polygons, this removes any fill parameters passed to the rendering function for LineStrings. It also just doesn't render any LineStrings with fewer than 2 points. Both of these cases should be in line with prior behavior.

See before + after below, rendering a line string which is the boundary of a triangle; notice the more intentional joins in the latter at each corner.
![Screenshot from 2024-05-05 17-12-02](https://github.com/georust/geo-svg/assets/90366517/d600c6cd-6419-4753-8d77-f9efbe5e18cd)
![Screenshot from 2024-05-05 17-11-27](https://github.com/georust/geo-svg/assets/90366517/6d04d00f-65c1-46c6-bd89-c92b203c6b2e)