### PR TITLE
feat: Add stroke style options (dashes, linecap, and linejoin)

### DIFF
--- a/images/linecap_butt.svg
+++ b/images/linecap_butt.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" viewBox="-68 -23 130 46">
+  <circle cx="0.0" cy="0.0" r="20" fill-opacity="0" stroke="blue" stroke-width="1" stroke-dasharray="5 3 3 3" stroke-linecap="butt"/>
+</svg>

--- a/images/linecap_round.svg
+++ b/images/linecap_round.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" viewBox="-68 -23 130 46">
+  <circle cx="0.0" cy="0.0" r="20" fill-opacity="0" stroke="blue" stroke-width="1" stroke-dasharray="5 3 3 3" stroke-linecap="round"/>
+</svg>
+

--- a/images/linecap_square.svg
+++ b/images/linecap_square.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" viewBox="-68 -23 130 46">
+  <circle cx="0.0" cy="0.0" r="20" fill-opacity="0" stroke="blue" stroke-width="1" stroke-dasharray="5 3 3 3" stroke-linecap="square"/>
+</svg>

--- a/images/linejoin_bevel.svg
+++ b/images/linejoin_bevel.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" viewBox="-68 -23 130 46">
+  <path fill-rule="evenodd" d="M -20 -20 L 20 -20 L 20 20 L -20 20 L -20 -20 Z " fill="green" fill-opacity="0.5" stroke="green" stroke-width="3" stroke-linejoin="bevel"/>
+</svg>
+

--- a/images/linejoin_miter.svg
+++ b/images/linejoin_miter.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" viewBox="-68 -23 130 46">
+  <path fill-rule="evenodd" d="M -20 -20 L 20 -20 L 20 20 L -20 20 L -20 -20 Z " fill="green" fill-opacity="0.5" stroke="green" stroke-width="3" stroke-linejoin="miter"/>
+</svg>
+

--- a/images/linejoin_round.svg
+++ b/images/linejoin_round.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" viewBox="-68 -23 130 46">
+  <path fill-rule="evenodd" d="M -20 -20 L 20 -20 L 20 20 L -20 20 L -20 -20 Z " fill="green" fill-opacity="0.5" stroke="green" stroke-width="3" stroke-linejoin="round"/>
+</svg>
+

--- a/src/style.rs
+++ b/src/style.rs
@@ -9,7 +9,7 @@ pub enum LineCap {
     Square,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LineJoin {
     Miter,
     Round,

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,16 +1,57 @@
 use crate::Color;
 use std::fmt::{Display, Formatter, Result};
 
+/**
+LineCap is used to define the shape to be used at the end of strokes.
+
+Example:
+```
+use geo::Point;
+use geo_svg::{Color, LineCap, ToSvg};
+
+let point = geo::Point::new(0.0, 0.0);
+let svg_point = point
+    .to_svg()
+    .with_radius(20.0)
+    .with_fill_opacity(0.0)
+    .with_stroke_color(Color::Named("blue"))
+    .with_stroke_width(1.0)
+    .with_stroke_linecap(LineCap::Round)
+    .with_stroke_dasharray(vec![2.0, 1.0, 3.0, 1.0]);
+```
+*/
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub enum LineCap {
-   #[default]
+    #[default]
     Butt,
     Round,
     Square,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+/**
+LineJoin is used to define the shape to be used at the corners of strokes.
+
+Example:
+```
+use geo::{Triangle};
+use geo_svg::{Color, LineJoin, ToSvg};
+
+let triangle = Triangle::new(
+    geo::Coord { x: 0.0, y: 0.0 },
+    geo::Coord { x: 10.0, y: 0.0 },
+    geo::Coord { x: 5.0, y: 10.0 },
+);
+let svg_triangle = triangle
+    .to_svg()
+    .with_fill_opacity(0.5)
+    .with_color(Color::Named("red"))
+    .with_stroke_width(2.0)
+    .with_stroke_linejoin(LineJoin::Bevel);
+```
+*/
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum LineJoin {
+    #[default]
     Miter,
     Round,
     Bevel,

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,25 +1,38 @@
 use crate::Color;
 use std::fmt::{Display, Formatter, Result};
 
-/**
-LineCap is used to define the shape to be used at the end of strokes.
-
-Example:
-```
-use geo::Point;
-use geo_svg::{Color, LineCap, ToSvg};
-
-let point = geo::Point::new(0.0, 0.0);
-let svg_point = point
-    .to_svg()
-    .with_radius(20.0)
-    .with_fill_opacity(0.0)
-    .with_stroke_color(Color::Named("blue"))
-    .with_stroke_width(1.0)
-    .with_stroke_linecap(LineCap::Round)
-    .with_stroke_dasharray(vec![2.0, 1.0, 3.0, 1.0]);
-```
-*/
+/// LineCap is used to define the shape to be used at the end of strokes.
+/// 
+/// Example:
+/// ```
+/// use geo::Point;
+/// use geo_svg::{Color, LineCap, ToSvg};
+/// 
+/// let point = geo::Point::new(0.0, 0.0);
+/// let svg_point = point
+///     .to_svg()
+///     .with_radius(20.0)
+///     .with_fill_opacity(0.0)
+///     .with_stroke_color(Color::Named("blue"))
+///     .with_stroke_width(1.0)
+///     .with_stroke_linecap(LineCap::Round)
+///     .with_stroke_dasharray(vec![2.0, 1.0, 3.0, 1.0]);
+/// ```
+///
+/// # Visual Examples
+///
+/// ### Butt
+///
+#[doc = include_str!("../images/linecap_butt.svg")]
+///
+/// ### Round
+///
+#[doc = include_str!("../images/linecap_round.svg")]
+///
+/// ### Square
+///
+#[doc = include_str!("../images/linecap_square.svg")]
+///
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub enum LineCap {
     #[default]
@@ -28,27 +41,41 @@ pub enum LineCap {
     Square,
 }
 
-/**
-LineJoin is used to define the shape to be used at the corners of strokes.
-
-Example:
-```
-use geo::{Triangle};
-use geo_svg::{Color, LineJoin, ToSvg};
-
-let triangle = Triangle::new(
-    geo::Coord { x: 0.0, y: 0.0 },
-    geo::Coord { x: 10.0, y: 0.0 },
-    geo::Coord { x: 5.0, y: 10.0 },
-);
-let svg_triangle = triangle
-    .to_svg()
-    .with_fill_opacity(0.5)
-    .with_color(Color::Named("red"))
-    .with_stroke_width(2.0)
-    .with_stroke_linejoin(LineJoin::Bevel);
-```
-*/
+/// LineJoin is used to define the shape to be used at the corners of strokes.
+///
+/// 
+/// Example:
+/// ```
+/// use geo::{Triangle};
+/// use geo_svg::{Color, LineJoin, ToSvg};
+/// 
+/// let triangle = Triangle::new(
+///     geo::Coord { x: 0.0, y: 0.0 },
+///     geo::Coord { x: 10.0, y: 0.0 },
+///     geo::Coord { x: 5.0, y: 10.0 },
+/// );
+/// let svg_triangle = triangle
+///     .to_svg()
+///     .with_fill_opacity(0.5)
+///     .with_color(Color::Named("red"))
+///     .with_stroke_width(2.0)
+///     .with_stroke_linejoin(LineJoin::Bevel);
+/// ```
+///
+/// # Visual Examples
+///
+/// ### Miter
+///
+#[doc = include_str!("../images/linejoin_miter.svg")]
+///
+/// ### Round
+///
+#[doc = include_str!("../images/linejoin_round.svg")]
+///
+/// ### Bevel
+///
+#[doc = include_str!("../images/linejoin_bevel.svg")]
+///
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum LineJoin {
     #[default]

--- a/src/style.rs
+++ b/src/style.rs
@@ -2,6 +2,19 @@ use crate::Color;
 use std::fmt::{Display, Formatter, Result};
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum LineCap {
+    Butt,
+    Round,
+    Square,
+}
+
+impl Default for LineCap {
+    fn default() -> Self {
+        LineCap::Butt
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct Style {
     pub opacity: Option<f32>,
     pub fill: Option<Color>,
@@ -9,6 +22,8 @@ pub struct Style {
     pub stroke_color: Option<Color>,
     pub stroke_width: Option<f32>,
     pub stroke_opacity: Option<f32>,
+    pub stroke_dasharray: Option<Vec<f32>>,
+    pub stroke_linecap: Option<LineCap>,
     pub radius: f32,
 }
 
@@ -21,6 +36,8 @@ impl Default for Style {
             stroke_color: None,
             stroke_width: None,
             stroke_opacity: None,
+            stroke_dasharray: None,
+            stroke_linecap: None,
             radius: 1.0,
         }
     }
@@ -45,6 +62,28 @@ impl Display for Style {
         }
         if let Some(stroke_opacity) = self.stroke_opacity {
             write!(fmt, r#" stroke-opacity="{}""#, stroke_opacity)?;
+        }
+        if let Some(stroke_dasharray) = &self.stroke_dasharray {
+            write!(
+                fmt,
+                r#" stroke-dasharray="{}""#,
+                stroke_dasharray
+                    .iter()
+                    .map(|f| f.to_string())
+                    .collect::<Vec<String>>()
+                    .join(" ")
+            )?;
+        }
+        if let Some(stroke_linecap) = &self.stroke_linecap {
+            write!(
+                fmt,
+                r#" stroke-linecap="{}""#,
+                match stroke_linecap {
+                    LineCap::Butt => "butt",
+                    LineCap::Round => "round",
+                    LineCap::Square => "square",
+                }
+            )?;
         }
         Ok(())
     }

--- a/src/style.rs
+++ b/src/style.rs
@@ -15,6 +15,13 @@ impl Default for LineCap {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum LineJoin {
+    Miter,
+    Round,
+    Bevel,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct Style {
     pub opacity: Option<f32>,
     pub fill: Option<Color>,
@@ -24,6 +31,7 @@ pub struct Style {
     pub stroke_opacity: Option<f32>,
     pub stroke_dasharray: Option<Vec<f32>>,
     pub stroke_linecap: Option<LineCap>,
+    pub stroke_linejoin: Option<LineJoin>,
     pub radius: f32,
 }
 
@@ -38,6 +46,7 @@ impl Default for Style {
             stroke_opacity: None,
             stroke_dasharray: None,
             stroke_linecap: None,
+            stroke_linejoin: None,
             radius: 1.0,
         }
     }
@@ -82,6 +91,17 @@ impl Display for Style {
                     LineCap::Butt => "butt",
                     LineCap::Round => "round",
                     LineCap::Square => "square",
+                }
+            )?;
+        }
+        if let Some(stroke_linejoin) = &self.stroke_linejoin {
+            write!(
+                fmt,
+                r#" stroke-linejoin="{}""#,
+                match stroke_linejoin {
+                    LineJoin::Miter => "miter",
+                    LineJoin::Round => "round",
+                    LineJoin::Bevel => "bevel",
                 }
             )?;
         }

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,17 +1,12 @@
 use crate::Color;
 use std::fmt::{Display, Formatter, Result};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub enum LineCap {
+   #[default]
     Butt,
     Round,
     Square,
-}
-
-impl Default for LineCap {
-    fn default() -> Self {
-        LineCap::Butt
-    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -1,4 +1,4 @@
-use crate::{Color, Style, ToSvgStr, ViewBox};
+use crate::{Color, LineCap, Style, ToSvgStr, ViewBox};
 use std::fmt::{Display, Formatter, Result};
 
 #[derive(Clone)]
@@ -81,6 +81,22 @@ impl<'a> Svg<'a> {
         self.style.stroke_color = Some(stroke_color);
         for sibling in &mut self.siblings {
             *sibling = sibling.clone().with_stroke_color(stroke_color);
+        }
+        self
+    }
+
+    pub fn with_stroke_dasharray(mut self, dasharray: Vec<f32>) -> Self {
+        self.style.stroke_dasharray = Some(dasharray.clone());
+        for sibling in &mut self.siblings {
+            *sibling = sibling.clone().with_stroke_dasharray(dasharray.clone());
+        }
+        self
+    }
+
+    pub fn with_stroke_linecap(mut self, linecap: LineCap) -> Self {
+        self.style.stroke_linecap = Some(linecap.clone());
+        for sibling in &mut self.siblings {
+            *sibling = sibling.clone().with_stroke_linecap(linecap.clone());
         }
         self
     }

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -1,4 +1,4 @@
-use crate::{Color, LineCap, Style, ToSvgStr, ViewBox};
+use crate::{Color, LineCap, LineJoin, Style, ToSvgStr, ViewBox};
 use std::fmt::{Display, Formatter, Result};
 
 #[derive(Clone)]
@@ -97,6 +97,14 @@ impl<'a> Svg<'a> {
         self.style.stroke_linecap = Some(linecap.clone());
         for sibling in &mut self.siblings {
             *sibling = sibling.clone().with_stroke_linecap(linecap.clone());
+        }
+        self
+    }
+
+    pub fn with_stroke_linejoin(mut self, linejoin: LineJoin) -> Self {
+        self.style.stroke_linejoin = Some(linejoin.clone());
+        for sibling in &mut self.siblings {
+            *sibling = sibling.clone().with_stroke_linejoin(linejoin.clone());
         }
         self
     }


### PR DESCRIPTION
Implementation of issue #18. What's new:
- Stroke dashing behaviour using a cycling vec of dash and gap lengths
- Specify a linecap style using the LineCap enum (Butt, Round, Square)
- Specify a line join style using the LineJoin enum (Miter, Round, Bevel)

Example usage:

```rust
use geo::{Coord, Point, Rect, Triangle};
use geo_svg::{Color, LineCap, LineJoin, ToSvg};


let point = geo::Point::new(0.0, 0.0);
let triangle = geo::Triangle::new(
    Coord { x: 20, y: 20 },
    Coord { x: 40, y: -20 },
    Coord { x: 60, y: 20 },
);
let rect = Rect::new(Coord { x: -65, y: -20 }, Coord { x: -25, y: 20 });

let svg_point = point
    .to_svg()
    .with_radius(20.0)
    .with_fill_opacity(0.0)
    .with_stroke_color(Color::Named("blue"))
    .with_stroke_width(1.0)
    .with_stroke_dasharray(vec![2.0, 1.0, 3.0, 1.0]); // 2 units on, 1 unit off, 3 units on, 1 unit off

let svg_triangle = triangle
    .to_svg()
    .with_fill_opacity(0.5)
    .with_color(Color::Named("red"))
    .with_stroke_width(2.0)
    .with_stroke_linecap(LineCap::Round)
    .with_stroke_linejoin(LineJoin::Round)
    .with_stroke_dasharray(vec![3.0, 3.0]); // 3 units on, 3 units off

let svg_rect = rect
    .to_svg()
    .with_fill_opacity(0.5)
    .with_color(Color::Named("green"))
    .with_stroke_width(3.0)
    .with_stroke_linejoin(LineJoin::Bevel); 
```

![example](https://github.com/user-attachments/assets/1135554d-11c9-43c5-b9ef-f83a3ee8cbae)
