### PR TITLE
Added the ability to change the absolute output size of the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Below is an example of a geometry collection rendered to SVG.
 - [GeometryCollection](https://docs.rs/geo-types/0.7.13/geo_types/geometry/struct.GeometryCollection.html) and all variants of [Geometry](https://docs.rs/geo-types/0.7.13/geo_types/geometry/enum.Geometry.html) are supported
 - the viewport size is automatically computed to contain all shapes
 - style and formatting options are available
+- the image size can be set in absolute units such as cm or px.
 
 ## Example
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -21,34 +21,28 @@ impl Display for Color {
     }
 }
 
-
 #[cfg(test)]
-mod tests
-{
+mod tests {
     use super::*;
 
     #[test]
-    fn test_named()
-    {
+    fn test_named() {
         assert_eq!(format!("{}", Color::Named("red")), "red");
     }
 
     #[test]
-    fn test_rgb()
-    {
+    fn test_rgb() {
         assert_eq!(format!("{}", Color::Rgb(255, 0, 0)), "rgb(255,0,0)");
     }
 
     #[test]
-    fn test_hex()
-    {
+    fn test_hex() {
         assert_eq!(format!("{}", Color::Hex(0xFF0000)), "#FF0000");
         assert_eq!(format!("{}", Color::Hex(0xFF)), "#0000FF");
     }
 
     #[test]
-    fn test_hsl()
-    {
+    fn test_hsl() {
         assert_eq!(format!("{}", Color::Hsl(0, 100, 50)), "hsl(0,100%,50%)");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ mod svg_impl;
 mod text;
 mod to_svg;
 mod to_svg_str;
+mod unit;
 mod viewbox;
 
 pub use color::*;
@@ -64,4 +65,5 @@ pub use svg::Svg;
 pub use text::*;
 pub use to_svg::*;
 pub use to_svg_str::*;
+pub use unit::Unit;
 pub use viewbox::ViewBox;

--- a/src/style.rs
+++ b/src/style.rs
@@ -2,12 +2,12 @@ use crate::Color;
 use std::fmt::{Display, Formatter, Result};
 
 /// LineCap is used to define the shape to be used at the end of strokes.
-/// 
+///
 /// Example:
 /// ```
 /// use geo::Point;
 /// use geo_svg::{Color, LineCap, ToSvg};
-/// 
+///
 /// let point = geo::Point::new(0.0, 0.0);
 /// let svg_point = point
 ///     .to_svg()
@@ -43,12 +43,12 @@ pub enum LineCap {
 
 /// LineJoin is used to define the shape to be used at the corners of strokes.
 ///
-/// 
+///
 /// Example:
 /// ```
 /// use geo::{Triangle};
 /// use geo_svg::{Color, LineJoin, ToSvg};
-/// 
+///
 /// let triangle = Triangle::new(
 ///     geo::Coord { x: 0.0, y: 0.0 },
 ///     geo::Coord { x: 10.0, y: 0.0 },

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -137,12 +137,14 @@ impl<'a> Svg<'a> {
             })
     }
 
-    /// Typically only `set_width` or `set_height is necessary. The other quantity is computed to match the aspect ratio of the view box.
+    /// Typically only `set_width` or `set_height is necessary.
+    /// The other quantity is computed to match the aspect ratio of the view box.
     pub fn set_width(&mut self, width: Unit) {
         self.width = Some(width);
     }
 
-    /// Typically only `set_width` or `set_height is necessary. The other quantity is computed to match the aspect ratio of the view box.
+    /// Typically only `set_width` or `set_height is necessary.
+    /// The other quantity is computed to match the aspect ratio of the view box.
     pub fn set_height(&mut self, height: Unit) {
         self.height = Some(height);
     }
@@ -158,16 +160,15 @@ impl Display for Svg<'_> {
             r#"<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" viewBox="{x} {y} {w} {h}""#,
             x = viewbox.min_x(),
             y = viewbox.min_y(),
-        ).and_then(|_| if self.width.is_some() || self.height.is_some() {
-                write!(
-                    fmt,
-                    r#" width="{width}" height="{height}""#,
-                    width = self.width.unwrap_or_else(|| self.height.unwrap().scale(w / h)),
-                    height = self.height.unwrap_or_else(|| self.width.unwrap().scale(h / w)),
-                )
-            } else {
-                Ok(())
-            }.and_then(|_| write!(fmt, r#">{content}</svg>"#, content = self.svg_str()))
-        )
+        )?;
+        if self.width.is_some() || self.height.is_some() {
+            write!(
+                fmt,
+                r#" width="{width}" height="{height}""#,
+                width = self.width.unwrap_or_else(|| self.height.unwrap().scale(w / h)),
+                height = self.height.unwrap_or_else(|| self.width.unwrap().scale(h / w)),
+            )?;
+        }
+        write!(fmt, r#">{content}</svg>"#, content = self.svg_str())
     }
 }

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -96,17 +96,17 @@ impl<'a> Svg<'a> {
     }
 
     pub fn with_stroke_linecap(mut self, linecap: LineCap) -> Self {
-        self.style.stroke_linecap = Some(linecap.clone());
+        self.style.stroke_linecap = Some(linecap);
         for sibling in &mut self.siblings {
-            *sibling = sibling.clone().with_stroke_linecap(linecap.clone());
+            *sibling = sibling.clone().with_stroke_linecap(linecap);
         }
         self
     }
 
     pub fn with_stroke_linejoin(mut self, linejoin: LineJoin) -> Self {
-        self.style.stroke_linejoin = Some(linejoin.clone());
+        self.style.stroke_linejoin = Some(linejoin);
         for sibling in &mut self.siblings {
-            *sibling = sibling.clone().with_stroke_linejoin(linejoin.clone());
+            *sibling = sibling.clone().with_stroke_linejoin(linejoin);
         }
         self
     }
@@ -148,7 +148,7 @@ impl<'a> Svg<'a> {
     }
 }
 
-impl<'a> Display for Svg<'a> {
+impl Display for Svg<'_> {
     fn fmt(&self, fmt: &mut Formatter) -> Result {
         let viewbox = self.viewbox();
         let w = viewbox.width();

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -1,4 +1,4 @@
-use crate::{Color, LineCap, LineJoin, Style, ToSvgStr, ViewBox};
+use crate::{Color, LineCap, LineJoin, Style, ToSvgStr, Unit, ViewBox};
 use std::fmt::{Display, Formatter, Result};
 
 #[derive(Clone)]
@@ -7,6 +7,8 @@ pub struct Svg<'a> {
     pub siblings: Vec<Svg<'a>>,
     pub viewbox: ViewBox,
     pub style: Style,
+    pub width: Option<Unit>,
+    pub height: Option<Unit>,
 }
 
 impl<'a> Svg<'a> {
@@ -134,24 +136,38 @@ impl<'a> Svg<'a> {
                 viewbox.add(&other_viewbox)
             })
     }
+
+    /// Typically only `set_width` or `set_height is necessary. The other quantity is computed to match the aspect ratio of the view box.
+    pub fn set_width(&mut self, width: Unit) {
+        self.width = Some(width);
+    }
+
+    /// Typically only `set_width` or `set_height is necessary. The other quantity is computed to match the aspect ratio of the view box.
+    pub fn set_height(&mut self, height: Unit) {
+        self.height = Some(height);
+    }
 }
 
 impl<'a> Display for Svg<'a> {
     fn fmt(&self, fmt: &mut Formatter) -> Result {
         let viewbox = self.viewbox();
+        let w = viewbox.width();
+        let h = viewbox.height();
         write!(
             fmt,
-            r#"<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" viewBox="{x} {y} {w} {h}">{content}</svg>"#,
+            r#"<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" viewBox="{x} {y} {w} {h}""#,
             x = viewbox.min_x(),
             y = viewbox.min_y(),
-            w = viewbox.width(),
-            h = viewbox.height(),
-            content = self
-                .items
-                .iter()
-                .map(|item| item.to_svg_str(&self.style))
-                .chain(self.siblings.iter().map(Svg::svg_str))
-                .collect::<String>()
+        ).and_then(|_| if self.width.is_some() || self.height.is_some() {
+                write!(
+                    fmt,
+                    r#" width="{width}" height="{height}""#,
+                    width = self.width.unwrap_or_else(|| self.height.unwrap().scale(w / h)),
+                    height = self.height.unwrap_or_else(|| self.width.unwrap().scale(h / w)),
+                )
+            } else {
+                Ok(())
+            }.and_then(|_| write!(fmt, r#">{content}</svg>"#, content = self.svg_str()))
         )
     }
 }

--- a/src/svg_impl.rs
+++ b/src/svg_impl.rs
@@ -239,7 +239,7 @@ impl<T: CoordNum> ToSvgStr for GeometryCollection<T> {
     }
 }
 
-impl<'a, T: ToSvgStr> ToSvgStr for &'a [T] {
+impl<T: ToSvgStr> ToSvgStr for &[T] {
     fn to_svg_str(&self, style: &Style) -> String {
         self.iter()
             .map(|geometry| geometry.to_svg_str(style))

--- a/src/to_svg.rs
+++ b/src/to_svg.rs
@@ -11,6 +11,8 @@ impl<T: ToSvgStr> ToSvg for T {
             siblings: vec![],
             viewbox: ViewBox::default(),
             style: Style::default(),
+            width: None,
+            height: None,
         }
     }
 }

--- a/src/to_svg_str.rs
+++ b/src/to_svg_str.rs
@@ -5,7 +5,7 @@ pub trait ToSvgStr {
     fn viewbox(&self, style: &Style) -> ViewBox;
 }
 
-impl<'a> ToSvgStr for Svg<'a> {
+impl ToSvgStr for Svg<'_> {
     fn to_svg_str(&self, style: &Style) -> String {
         self.clone().with_style(style).to_string()
     }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1,0 +1,73 @@
+use std::fmt::{Display, Formatter, Result};
+
+/// Represents a quantity in absolute CSS units.
+///
+/// Relative units `%`, `em`, `rem`, `vh` and `vw` are not supported.
+#[derive(Clone, Copy, Debug)]
+pub enum Unit {
+    /// Centimeter (cm), 37.8px
+    Centimeter(f32),
+    /// Inch (in), 2.54cm, exactly 96px, 72pt, 6pc
+    Inch(f32),
+    /// No units, defaults as appropriate based on context
+    None(f32),
+    /// Millimeter (mm), 0.1cm
+    Millimeter(f32),
+    /// Pica (pc), 1/6 in, 12pt, 16px
+    Pica(f32),
+    /// Pixel (px), 1/96 in, 2/3 pt, 1/16 pc
+    Pixel(f32),
+    /// Point (pt), 1/72 in or 4/3 px, 1/12 pc
+    Point(f32),
+    /// Quarter-millimeter (Q), 1/4 mm, or 1/40 cm
+    QuarterMillimeter(f32),
+}
+
+impl Unit {
+    /// raw value with no units
+    pub fn value(&self) -> f32 {
+        match self {
+            Self::Centimeter(value) => *value,
+            Self::Inch(value) => *value,
+            Self::None(value) => *value,
+            Self::Millimeter(value) => *value,
+            Self::Pica(value) => *value,
+            Self::Pixel(value) => *value,
+            Self::Point(value) => *value,
+            Self::QuarterMillimeter(value) => *value,
+        }
+    }
+
+    /// abbreviated symbol of the unit
+    pub fn symbol(&self) -> &'static str {
+        match self {
+            Self::Centimeter(_) => "cm",
+            Self::Inch(_) => "in",
+            Self::None(_) => "",
+            Self::Millimeter(_) => "mm",
+            Self::Pica(_) => "pc",
+            Self::Pixel(_) => "px",
+            Self::Point(_) => "pt",
+            Self::QuarterMillimeter(_) => "Q",
+        }
+    }
+
+    pub fn scale(&self, factor: f32) -> Self {
+        match self {
+            Self::Centimeter(value) => Self::Centimeter(value * factor),
+            Self::Inch(value) => Self::Inch(value * factor),
+            Self::None(value) => Self::None(value * factor),
+            Self::Millimeter(value) => Self::Millimeter(value * factor),
+            Self::Pica(value) => Self::Pica(value * factor),
+            Self::Pixel(value) => Self::Pixel(value * factor),
+            Self::Point(value) => Self::Point(value * factor),
+            Self::QuarterMillimeter(value) => Self::QuarterMillimeter(value * factor),
+        }
+    }
+}
+
+impl Display for Unit {
+    fn fmt(&self, fmt: &mut Formatter) -> Result {
+        write!(fmt, "{value}{symbol}", value = self.value(), symbol = self.symbol())
+    }
+}

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -25,21 +25,21 @@ pub enum Unit {
 
 impl Unit {
     /// raw value with no units
-    pub fn value(&self) -> f32 {
+    pub fn value(self) -> f32 {
         match self {
-            Self::Centimeter(value) => *value,
-            Self::Inch(value) => *value,
-            Self::None(value) => *value,
-            Self::Millimeter(value) => *value,
-            Self::Pica(value) => *value,
-            Self::Pixel(value) => *value,
-            Self::Point(value) => *value,
-            Self::QuarterMillimeter(value) => *value,
+            Self::Centimeter(value) => value,
+            Self::Inch(value) => value,
+            Self::None(value) => value,
+            Self::Millimeter(value) => value,
+            Self::Pica(value) => value,
+            Self::Pixel(value) => value,
+            Self::Point(value) => value,
+            Self::QuarterMillimeter(value) => value,
         }
     }
 
     /// abbreviated symbol of the unit
-    pub fn symbol(&self) -> &'static str {
+    pub fn symbol(self) -> &'static str {
         match self {
             Self::Centimeter(_) => "cm",
             Self::Inch(_) => "in",
@@ -52,7 +52,7 @@ impl Unit {
         }
     }
 
-    pub fn scale(&self, factor: f32) -> Self {
+    pub fn scale(self, factor: f32) -> Self {
         match self {
             Self::Centimeter(value) => Self::Centimeter(value * factor),
             Self::Inch(value) => Self::Inch(value * factor),

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -68,6 +68,11 @@ impl Unit {
 
 impl Display for Unit {
     fn fmt(&self, fmt: &mut Formatter) -> Result {
-        write!(fmt, "{value}{symbol}", value = self.value(), symbol = self.symbol())
+        write!(
+            fmt,
+            "{value}{symbol}",
+            value = self.value(),
+            symbol = self.symbol()
+        )
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

The main change adds `set_width` and `set_height` to `struct Svg`. The quantities are separate because only one needs to be set in most cases. Both come in a new `Unit` enum which helps with the display.

The problem that this is trying to solve is that my SVG viewer, Inkscape, has finite zoom capabilities. When displaying a polygon that has meter-level features across a 0.1 degree grid, the finer details are invisible because the entire image is only 0.1 user units in size. Adding appropriate `width` and `height` attributes to the top level `<svg>` tag fixes this issue by making the result larger without altering the user coordinates of the content.

Notes:
- As an ancillary "feature", ran `rustfmt` and `cargo clippy` on the entire repo. The results are in separate commits.
- Not sure what to do about the CHANGELOG entry, it seems to be a bit out of date as it is.
- I tried to keep with the style of the rest of the package as much as possible. Happy to modify or rewrite as necessary. My only real goal is to have those "width" and "height" attributes show up when set.