### PR TITLE
Use `geo-types` instead of `geo` for fewer dependency updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
+
+## Unreleased
+
+- Use geo-types instead of geo for fewer dependency updates.
+
 ## 0.6.2 - 2024-02-14
 #### Bug Fixes
 - partially fix `Color` which would misinterpret numbers like `0000FF` as `#FF` b09033d30c1cbb1886ae69b6ced3545be82a78e2 - vargad

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,23 @@
 [package]
 name = "geo-svg"
 version = "0.7.3"
-authors = ["Gérald Lelong <gerald.lelong@easymov.fr>", "RobWalt <robwalter96@gmail.com>"]
+authors = [
+    "Gérald Lelong <gerald.lelong@easymov.fr>",
+    "RobWalt <robwalter96@gmail.com>",
+]
 edition = "2021"
 license = "ISC"
 readme = "README.md"
 repository = "https://github.com/georust/geo-svg"
 description = "Convert geo types to SVG strings for visualization"
 keywords = ["geo", "polygon", "svg", "visualization"]
-categories = ["development-tools::debugging", "graphics", "multimedia::images", "visualization"]
+categories = [
+    "development-tools::debugging",
+    "graphics",
+    "multimedia::images",
+    "visualization",
+]
 
 [dependencies]
-geo = { version = "0.30.0", default-features = false }
+geo-types = "0.7"
 num-traits = "0.2.17"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,12 @@
 //!
 //! # Example
 //!
-//! The following will show how to convert a line to a SVG string.  
+//! The following will show how to convert a line to a SVG string.
 //! The [`to_svg`] method is provided by the [`ToSvg`] trait which is implemented for all [geo-types](https://docs.rs/geo-types/0.7.13/geo_types/).
 //!
 //! ```
 //! # fn main() {
-//! use geo::{Coord, Line, Point};
+//! use geo_types::{Coord, Line, Point};
 //! use geo_svg::{Color, ToSvg};
 //! let point = Point::new(10.0, 28.1);
 //! let line = Line::new(

--- a/src/style.rs
+++ b/src/style.rs
@@ -5,10 +5,10 @@ use std::fmt::{Display, Formatter, Result};
 ///
 /// Example:
 /// ```
-/// use geo::Point;
+/// use geo_types::Point;
 /// use geo_svg::{Color, LineCap, ToSvg};
 ///
-/// let point = geo::Point::new(0.0, 0.0);
+/// let point = geo_types::Point::new(0.0, 0.0);
 /// let svg_point = point
 ///     .to_svg()
 ///     .with_radius(20.0)
@@ -46,13 +46,13 @@ pub enum LineCap {
 ///
 /// Example:
 /// ```
-/// use geo::{Triangle};
+/// use geo_types::{Triangle};
 /// use geo_svg::{Color, LineJoin, ToSvg};
 ///
 /// let triangle = Triangle::new(
-///     geo::Coord { x: 0.0, y: 0.0 },
-///     geo::Coord { x: 10.0, y: 0.0 },
-///     geo::Coord { x: 5.0, y: 10.0 },
+///     geo_types::Coord { x: 0.0, y: 0.0 },
+///     geo_types::Coord { x: 10.0, y: 0.0 },
+///     geo_types::Coord { x: 5.0, y: 10.0 },
 /// );
 /// let svg_triangle = triangle
 ///     .to_svg()

--- a/src/svg_impl.rs
+++ b/src/svg_impl.rs
@@ -1,5 +1,5 @@
 use crate::{Style, ToSvgStr, ViewBox};
-use geo::{
+use geo_types::{
     Coord, CoordNum, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
     MultiPolygon, Point, Polygon, Rect, Triangle,
 };
@@ -270,7 +270,7 @@ impl<T: ToSvgStr> ToSvgStr for Vec<T> {
 #[cfg(test)]
 mod tests {
     use crate::{Color, ToSvg};
-    use geo::{LineString, Point, Polygon};
+    use geo_types::{LineString, Point, Polygon};
 
     #[test]
     fn test_point() {

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use geo::{Coord, CoordNum};
+use geo_types::{Coord, CoordNum};
 
 use crate::{Style, ToSvgStr, ViewBox};
 


### PR DESCRIPTION
- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---
