### PR TITLE
Prepare release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
-## Unreleased
+## 0.8.0 - 2025-07-12
 
 - Updated to rust 2024 edition
 - Use geo-types instead of geo for fewer dependency updates.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geo-svg"
-version = "0.7.3"
+version = "0.8.0"
 authors = [
     "Gérald Lelong <gerald.lelong@easymov.fr>",
     "RobWalt <robwalter96@gmail.com>",


### PR DESCRIPTION
The existing version on crates.io is 0.7.3, even though the last entry in the changelog was 0.6.*

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

Closes https://github.com/georust/geo-svg/issues/25