### PR TITLE
feat!: allow `Color::Named` with limited lifetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
+## Unreleased
+#### Features
+- BREAKING: allow `Color::Named` with limited lifetimes - benedikt-schaber
+
 ## 0.8.0 - 2025-07-12
 
 - Updated to rust 2024 edition

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,14 +1,14 @@
 use std::fmt::{Display, Formatter, Result};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum Color {
-    Named(&'static str),
+pub enum Color<'a> {
+    Named(&'a str),
     Rgb(u8, u8, u8),
     Hex(u32),
     Hsl(u16, u8, u8),
 }
 
-impl Display for Color {
+impl Display for Color<'_> {
     fn fmt(&self, fmt: &mut Formatter) -> Result {
         match self {
             Color::Named(name) => write!(fmt, "{name}"),

--- a/src/style.rs
+++ b/src/style.rs
@@ -85,11 +85,11 @@ pub enum LineJoin {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Style {
+pub struct Style<'a> {
     pub opacity: Option<f32>,
-    pub fill: Option<Color>,
+    pub fill: Option<Color<'a>>,
     pub fill_opacity: Option<f32>,
-    pub stroke_color: Option<Color>,
+    pub stroke_color: Option<Color<'a>>,
     pub stroke_width: Option<f32>,
     pub stroke_opacity: Option<f32>,
     pub stroke_dasharray: Option<Vec<f32>>,
@@ -98,7 +98,7 @@ pub struct Style {
     pub radius: f32,
 }
 
-impl Default for Style {
+impl Default for Style<'_> {
     fn default() -> Self {
         Self {
             opacity: None,
@@ -115,7 +115,7 @@ impl Default for Style {
     }
 }
 
-impl Display for Style {
+impl Display for Style<'_> {
     fn fmt(&self, fmt: &mut Formatter) -> Result {
         if let Some(opacity) = self.opacity {
             write!(fmt, r#" opacity="{opacity}""#)?;

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -6,7 +6,7 @@ pub struct Svg<'a> {
     pub items: Vec<&'a dyn ToSvgStr>,
     pub siblings: Vec<Svg<'a>>,
     pub viewbox: ViewBox,
-    pub style: Style,
+    pub style: Style<'a>,
     pub width: Option<Unit>,
     pub height: Option<Unit>,
 }
@@ -17,7 +17,7 @@ impl<'a> Svg<'a> {
         self
     }
 
-    pub fn with_style(mut self, style: &Style) -> Self {
+    pub fn with_style(mut self, style: &Style<'a>) -> Self {
         self.style = style.clone();
         for sibling in &mut self.siblings {
             *sibling = sibling.clone().with_style(style);
@@ -30,7 +30,7 @@ impl<'a> Svg<'a> {
         self
     }
 
-    pub fn with_color(mut self, color: Color) -> Self {
+    pub fn with_color(mut self, color: Color<'a>) -> Self {
         self.style.fill = Some(color);
         self.style.stroke_color = Some(color);
         for sibling in &mut self.siblings {
@@ -47,7 +47,7 @@ impl<'a> Svg<'a> {
         self
     }
 
-    pub fn with_fill_color(mut self, fill: Color) -> Self {
+    pub fn with_fill_color(mut self, fill: Color<'a>) -> Self {
         self.style.fill = Some(fill);
         for sibling in &mut self.siblings {
             *sibling = sibling.clone().with_fill_color(fill);
@@ -79,7 +79,7 @@ impl<'a> Svg<'a> {
         self
     }
 
-    pub fn with_stroke_color(mut self, stroke_color: Color) -> Self {
+    pub fn with_stroke_color(mut self, stroke_color: Color<'a>) -> Self {
         self.style.stroke_color = Some(stroke_color);
         for sibling in &mut self.siblings {
             *sibling = sibling.clone().with_stroke_color(stroke_color);


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---
## Motivation
Currently `Color::Named` requires static lifetime. This is inconvenient in some circumstances, e.g. in the web, when getting the color from a color picker which might return a named color like `"red"`.

Further, since `Color` is only ever formatted to a string, technically the only limit to `Color::Named` is that it adheres to the svg/html spec, so something like a hex string can also be used directly. With this change this will also allow such strings with limited lifetimes, avoiding the need to first parse and then stringify a hex string again, adding simplicity and potential performance increases in this case as well. E.g. for the web input example above, we could directly use its output without differentiating between named color and hex string.

## Changes
This requires adding generic lifetimes to `Color` and `Style`, making it a breaking change to their signatures. The impact, however, isn't that big, since `Svg` already has a generic lifetime.

---
I can also prepare a new release if you want :)